### PR TITLE
Add support for user to supply a fixed column width

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,12 @@ vim.keymap.set("v", "<Leader>c", require('columnize').columnize,
 
 Select the lines you want to columnize and run the command `Columnize`. You can
 also invoke this tool by assigning it a key combination, as explained earlier.
+
+The command `Columnize` uses the maximum word length as column width per default.
+
+If you instead want to use a fixed column width, supply the wanted column width
+as an argument, like this: `Columnize 12`.
+
+Note that a column width of `12` means that a word with a maximum of 12
+positions will fit in it. . Columns are divided by spaces and these spaces are
+not included in the `fixed column width` parameter.

--- a/lua/columnize/init.lua
+++ b/lua/columnize/init.lua
@@ -3,28 +3,32 @@ local strings = require('columnize.strings')
 
 local M = {}
 
-function M.columnize_lines(buffer, start_line, end_line)
+function M.columnize_lines(buffer, start_line, end_line, column_width)
     local lines_in = editor.get_lines(buffer, start_line, end_line)
     local indent = strings.left_whitespace(lines_in[1])
     local max_len = strings.max_word_length_in_lines(lines_in)
-    local lines_out = strings.columnize_lines(lines_in, indent, max_len)
+    if column_width == nil then
+        column_width = max_len
+    end
+    local lines_out = strings.columnize_lines(lines_in, indent, column_width)
     editor.set_lines(buffer, start_line, end_line, lines_out)
 end
 
 function M.columnize()
     local buffer = 0
     local start_line, end_line = editor.get_selected_lines()
-    M.columnize_lines(buffer, start_line, end_line)
+    M.columnize_lines(buffer, start_line, end_line, nil)
 end
 
 function M.columnize_cmd(ctx)
     local buffer = 0
     local start_line, end_line = ctx.line1, ctx.line2
-    M.columnize_lines(buffer, start_line, end_line)
+    local column_width = tonumber(ctx.args)
+    M.columnize_lines(buffer, start_line, end_line, column_width)
 end
 
 function M.setup(...)
-    vim.api.nvim_create_user_command('Columnize', M.columnize_cmd, {range=true})
+    vim.api.nvim_create_user_command('Columnize', M.columnize_cmd, { range = true, nargs = '?' })
 end
 
 return M

--- a/lua/columnize/strings.lua
+++ b/lua/columnize/strings.lua
@@ -31,18 +31,18 @@ function M.max_word_length_in_lines(lines)
     return max_len
 end
 
-function M.columnize_line(line, indent, word_length)
+function M.columnize_line(line, indent, column_width)
     local res = {}
     for w in M.split(line) do
-        table.insert(res, indent .. pstrings.align_str(w, word_length, false))
+        table.insert(res, indent .. pstrings.align_str(w, column_width, false))
     end
     return M.rtrim(table.concat(res, ' '))
 end
 
-function M.columnize_lines(lines, indent, word_length)
+function M.columnize_lines(lines, indent, column_width)
     local res = {}
     for _, line in ipairs(lines) do
-        table.insert(res, M.columnize_line(line, indent, word_length))
+        table.insert(res, M.columnize_line(line, indent, column_width))
     end
     return res
 end


### PR DESCRIPTION
By supplying an argument when invoking the user command `Columnize` a user is now able to specify the fixed column width.